### PR TITLE
add support for the device code flow

### DIFF
--- a/cmd/devicecodecmd.go
+++ b/cmd/devicecodecmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/gladstomych/tokensmith/internal/auth"
+	"github.com/gladstomych/tokensmith/internal/classes"
 	"github.com/spf13/cobra"
 )
 
@@ -23,4 +24,5 @@ Often only used by offensive tooling and hence we consider it opsec unsafe.
 
 func init() {
 	rootCmd.AddCommand(devicecodeCmd)
+	devicecodeCmd.Flags().StringVarP(&classes.ResourceURL, "resource", "r", "urn:ms-drs:enterpriseregistration.windows.net", "Resource URL to request token for.")
 }

--- a/internal/auth/authutils.go
+++ b/internal/auth/authutils.go
@@ -45,3 +45,35 @@ func parseRespTokens(respBody string) error {
 	//return &tr, nil //in case you want to return the response for something in future
 	return nil
 }
+
+func parseDeviceAuthorizationResponse(respBody string) (string, string, string, error) {
+	var dcr classes.DeviceAuthorizationResponse
+	err := json.Unmarshal([]byte(respBody), &dcr)
+	if err != nil {
+		fmt.Errorf("response is not valid JSON: %w", err)
+		return "", "", "", err
+	}
+
+	return dcr.VerificationURL, dcr.DeviceCode, dcr.UserCode, nil
+}
+
+func parseDeviceAuthRespTokens(respBody string) error {
+	var tr classes.DeviceCodeAuthenticationResponse
+	err := json.Unmarshal([]byte(respBody), &tr)
+	if err != nil {
+		return fmt.Errorf("response is not valid JSON: %w", err)
+	}
+
+	// Check all required fields
+	if tr.AccessToken == "" || tr.Scope == "" {
+		return fmt.Errorf("Token parsing error: missing one or more required fields (access_token, scope). Raw response: %s", respBody)
+	}
+
+	fmt.Println("\n[+] SUCCESSFULLY REDEEMED TOKEN!")
+	// Print the tokens nicely
+	fmt.Printf("\n[+] Access Token: \n============================\n%s\n", tr.AccessToken)
+	fmt.Printf("\n[+] Scope: \n=============================\n%s\n", tr.Scope)
+	fmt.Printf("\n[+] Resource: \n=============================\n%s\n", classes.ResourceURL)
+
+	return nil
+}

--- a/internal/auth/devcodeflow.go
+++ b/internal/auth/devcodeflow.go
@@ -2,8 +2,104 @@ package auth
 
 import (
 	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gladstomych/tokensmith/internal/classes"
 )
 
+func reqDeviceCodeFlow(ClientID, resourceURL, userAgent string) (string, error) {
+	deviceCodeURL := classes.DeviceCodeEndpoint
+	body := fmt.Sprintf("client_id=%s&resource=%s", ClientID, resourceURL)
+
+	Client := &http.Client{}
+	req, err := http.NewRequest("POST", deviceCodeURL, strings.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := Client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	verificationURI, deviceCode, userCode, err := parseDeviceAuthorizationResponse(string(respBody))
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Printf("To authenticate, visit %s and enter the code: %s\n", verificationURI, userCode)
+	return deviceCode, nil
+}
+
+func pollDeviceCodeFlow(ClientID, deviceCode, userAgent string) error {
+	tokenURL := classes.TokenV2Endpoint
+	body := fmt.Sprintf("client_id=%s&grant_type=urn:ietf:params:oauth:grant-type:device_code&device_code=%s", ClientID, deviceCode)
+
+	Client := &http.Client{}
+	for {
+		req, err := http.NewRequest("POST", tokenURL, strings.NewReader(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("User-Agent", userAgent)
+
+		resp, err := Client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		if strings.Contains(string(respBody), "authorization_pending") {
+			fmt.Println("Authorization pending. Retrying...")
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		err = parseDeviceAuthRespTokens(string(respBody))
+		if err != nil {
+			return err
+		}
+
+		break
+	}
+
+	return nil
+}
+
 func GetTknFromDevCode() {
-	fmt.Println("TODO. Not yet implemented.")
+	clientID := classes.ClientID
+	// scope := classes.Scope
+	resourceURL := classes.ResourceURL
+
+	deviceCode, err := reqDeviceCodeFlow(clientID, resourceURL, classes.UserAgent)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	fmt.Println("Waiting for user to complete authentication...")
+
+	err = pollDeviceCodeFlow(clientID, deviceCode, classes.UserAgent)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	fmt.Println("Authentication successful.")
 }

--- a/internal/auth/devcodeflow.go
+++ b/internal/auth/devcodeflow.go
@@ -86,7 +86,6 @@ func pollDeviceCodeFlow(ClientID, deviceCode, userAgent string) error {
 
 func GetTknFromDevCode() {
 	clientID := classes.ClientID
-	// scope := classes.Scope
 	resourceURL := classes.ResourceURL
 
 	deviceCode, err := reqDeviceCodeFlow(clientID, resourceURL, classes.UserAgent)

--- a/internal/classes/const.go
+++ b/internal/classes/const.go
@@ -13,5 +13,6 @@ var RefreshToken string   // "0.A.."
 const AuthorizeV2Endpoint string = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
 const TokenV2Endpoint string = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
 const TokenV1Endpoint string = "https://login.microsoftonline.com/common/oauth2/token"
+const DeviceCodeEndpoint string = "https://login.microsoftonline.com/common/oauth2/devicecode"
 
 // const TokenV2Endpoint string = "http://localhost:8000/post"

--- a/internal/classes/structs.go
+++ b/internal/classes/structs.go
@@ -5,3 +5,22 @@ type TokenResponse struct {
 	RefreshToken string `json:"refresh_token"`
 	Scope        string `json:"scope"`
 }
+
+type DeviceAuthorizationResponse struct {
+	UserCode        string `json:"user_code"`
+	DeviceCode      string `json:"device_code"`
+	VerificationURL string `json:"verification_url"`
+	ExpiresIn       string `json:"expires_in"`
+	Interval        string `json:"interval"`
+	Message         string `json:"message"`
+}
+
+type DeviceCodeAuthenticationResponse struct {
+	TokenType    string `json:"token_type"`
+	Scope        string `json:"scope"`
+	ExpiresIn    int    `json:"expires_in"`
+	ExtExpiresIn int    `json:"ext_expires_in"`
+	AccessToken  string `json:"access_token"`
+	Foci         string `json:"foci"`
+	IDToken      string `json:"id_token"`
+}


### PR DESCRIPTION
Added the implementation of the device code flow. It takes the clientId (-c) and ResourceURL (-r) as optional arguments